### PR TITLE
Remove flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1695145219,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,21 +2,29 @@
   description = "update-input";
 
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
-          packages.default = pkgs.writeShellScriptBin "update-input" ''
-            input=$(nix flake metadata --json | ${pkgs.jq}/bin/jq ".locks.nodes.root.inputs[]" | sed "s/\"//g" | ${pkgs.fzf}/bin/fzf)
-            nix flake lock --update-input $input
-          '';
-        }
-      );
+  outputs = { nixpkgs, ... }:
+    let
+      forAllSystems = function:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ]
+          (system: function nixpkgs.legacyPackages.${system});
+    in {
+      packages = forAllSystems (pkgs: {
+        default = pkgs.writeShellScriptBin "update-input" ''
+          input=$(                                           \
+            nix flake metadata --json                        \
+            | ${pkgs.jq}/bin/jq ".locks.nodes.root.inputs[]" \
+            | sed "s/\"//g"                                  \
+            | ${pkgs.fzf}/bin/fzf)
+          nix flake lock --update-input $input
+        '';
+      });
+    };
 }


### PR DESCRIPTION
Remove unneeded flake-utils in favor of `nixpkgs.lib.genAttr [ ... ]` pattern.
See [this post](https://ayats.org/blog/no-flake-utils/) on the matter