### PR TITLE
pass correct values to 'nix flake lock --update-input'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         default = pkgs.writeShellScriptBin "update-input" ''
           input=$(                                           \
             nix flake metadata --json                        \
-            | ${pkgs.jq}/bin/jq ".locks.nodes.root.inputs[]" \
+            | ${pkgs.jq}/bin/jq ".locks.nodes.root.inputs | keys[]" \
             | sed "s/\"//g"                                  \
             | ${pkgs.fzf}/bin/fzf)
           nix flake lock --update-input $input


### PR DESCRIPTION
```
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
    helix-git.url = "github:helix-editor/helix";
  };
  # ...... rest flake.nix
}
```
the above produces 2 nixpkgs inputs, one from helix-git and another mentioned in the flake above.

```
$ nix flake metadata --json | jq ".locks.nodes.root.inputs"
{
  "helix-git": "helix-git",
  "nixpkgs": "nixpkgs_2"
}

$ nix flake metadata --json | jq ".locks.nodes.root.inputs[]"
"helix-git"
"nixpkgs_2"

$ nix flake metadata --json | jq ".locks.nodes.root.inputs | keys[]"
"helix-git"
"nixpkgs"
```

`nix flake lock --update-input` seems to require 'nixpkgs' instead of the 'nixpkgs_2' for updating the input correctly.