### PR TITLE
remove avoidable sed call

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,7 @@
         default = pkgs.writeShellScriptBin "update-input" ''
           input=$(                                           \
             nix flake metadata --json                        \
-            | ${pkgs.jq}/bin/jq ".locks.nodes.root.inputs | keys[]" \
-            | sed "s/\"//g"                                  \
+            | ${pkgs.jq}/bin/jq -r ".locks.nodes.root.inputs | keys[]" \
             | ${pkgs.fzf}/bin/fzf)
           nix flake lock --update-input $input
         '';


### PR DESCRIPTION
`jq` has a flag `-r` which prints raw output for consumption by other tool.