### PR TITLE
Updated flake update call to match new syntax

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,13 @@
             nix flake metadata --json                        \
             | ${pkgs.jq}/bin/jq -r ".locks.nodes.root.inputs | keys[]" \
             | ${pkgs.fzf}/bin/fzf)
-          nix flake update $input
+          commit=$(printf "yes\nno" | ${pkgs.fzf}/bin/fzf --prompt="Commit lock file? ")
+
+          if [ "$commit" = "yes" ]; then
+            nix flake update $input --commit-lock-file
+          else
+            nix flake update $input
+          fi
         '';
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             nix flake metadata --json                        \
             | ${pkgs.jq}/bin/jq -r ".locks.nodes.root.inputs | keys[]" \
             | ${pkgs.fzf}/bin/fzf)
-          nix flake lock --update-input $input
+          nix flake update $input
         '';
       });
     };


### PR DESCRIPTION
fixes error:

`warning: '--update-input' is a deprecated alias for 'flake update' and will be removed in a future version.`